### PR TITLE
removed osx build from travis based on the pricing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
     - rabbitmq
     - memcached
     - postgresql
-  - os: osx
-    language: generic
-    osx_image: xcode8.3
 
 # command to install dependencies
 install:


### PR DESCRIPTION
This mitigates https://github.com/NAL-i5K/genomics-workspace/pull/197